### PR TITLE
change default servo pulse range from 1000-2000 to 550-2400

### DIFF
--- a/adafruit_motor/servo.py
+++ b/adafruit_motor/servo.py
@@ -40,7 +40,7 @@ class _BaseServo: # pylint: disable-msg=too-few-public-methods
        :param ~pulseio.PWMOut pwm_out: PWM output object.
        :param int min_pulse: The minimum pulse length of the servo in microseconds.
        :param int max_pulse: The maximum pulse length of the servo in microseconds."""
-    def __init__(self, pwm_out, *, min_pulse=1000, max_pulse=2000):
+    def __init__(self, pwm_out, *, min_pulse=550, max_pulse=2400):
         self._min_duty = int((min_pulse * pwm_out.frequency) / 1000000 * 0xffff)
         max_duty = (max_pulse * pwm_out.frequency) / 1000000 * 0xffff
         self._duty_range = int(max_duty - self._min_duty)
@@ -64,7 +64,7 @@ class Servo(_BaseServo):
          duty in degrees.
        :param int min_pulse: The minimum pulse length of the servo in microseconds.
        :param int max_pulse: The maximum pulse length of the servo in microseconds."""
-    def __init__(self, pwm_out, *, actuation_range=180, min_pulse=1000, max_pulse=2000):
+    def __init__(self, pwm_out, *, actuation_range=180, min_pulse=550, max_pulse=2400):
         super().__init__(pwm_out, min_pulse=min_pulse, max_pulse=max_pulse)
         self._actuation_range = actuation_range
         self._pwm = pwm_out

--- a/examples/continuous_servo.py
+++ b/examples/continuous_servo.py
@@ -19,11 +19,11 @@ pca = PCA9685(i2c)
 # pca = PCA9685(i2c, reference_clock_speed=25630710)
 pca.frequency = 50
 
-# The pulse range is 1000 - 2000 by default.
+# The pulse range is 550 - 2400 by default.
 servo7 = servo.ContinuousServo(pca.channels[7])
 # If your servo doesn't stop once the script is finished you may need to tune the
 # reference_clock_speed above or the min_pulse and max_pulse timings below.
-# servo7 = servo.ContinuousServo(pca.channels[7], min_pulse=1000, max_pulse=2000)
+# servo7 = servo.ContinuousServo(pca.channels[7], min_pulse=550, max_pulse=2400)
 
 print("Forwards")
 servo7.throttle = 1

--- a/examples/servo_sweep.py
+++ b/examples/servo_sweep.py
@@ -33,7 +33,7 @@ pca.frequency = 50
 # This is an example for the Micro servo - TowerPro SG-92R: https://www.adafruit.com/product/169
 # servo7 = servo.Servo(pca.channels[7], min_pulse=500, max_pulse=2400)
 
-# The pulse range is 1000 - 2000 by default.
+# The pulse range is 550 - 2400 by default.
 servo7 = servo.Servo(pca.channels[7])
 
 # We sleep in the loops to give the servo time to move into position.


### PR DESCRIPTION
This matches the values needed by the servos sold by Adafruit.

As requested by @ladyada. After approval I'll update the version in the Crickit CircuitPython builds.