### PR TITLE
don't set stepper freq if it's already OK

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,8 @@ deploy:
     tags: true
 
 install:
-  - pip install pylint circuitpython-build-tools Sphinx sphinx-rtd-theme pytest
+  - pip install --force-reinstall pylint==1.9.2
+  - pip install circuitpython-build-tools Sphinx sphinx-rtd-theme pytest
 
 script:
   - py.test

--- a/adafruit_motor/stepper.py
+++ b/adafruit_motor/stepper.py
@@ -75,7 +75,8 @@ class StepperMotor:
 
 	# set a safe pwm freq for each output
         for i in range(4):
-            self._coil[i].frequency = 2000
+            if self._coil[i].frequency < 1500:
+                self._coil[i].frequency = 2000
 
         self._current_microstep = 0
         if microsteps < 2:

--- a/tests/test_stepper.py
+++ b/tests/test_stepper.py
@@ -15,6 +15,10 @@ class Coil:
         self._duty_cycle = 0
 
     @property
+    def frequency(self):
+        return 1500
+
+    @property
     def duty_cycle(self):
         return self._duty_cycle
 


### PR DESCRIPTION
Fixes #12.

Some PWM-like classes don't allow setting frequency. Check if frequency is an acceptable value and don't try to change it if it's already OK.