### PR TITLE
PWMOut variable frequency not required, uses only one counter

### DIFF
--- a/adafruit_motor/stepper.py
+++ b/adafruit_motor/stepper.py
@@ -69,6 +69,9 @@ class StepperMotor:
     :param ~pulseio.PWMOut bin2: `pulseio.PWMOut`-compatible output connected to the driver for
       the fourth coil (unipolar) or second input to second coil (bipolar).
     :param int microsteps: Number of microsteps between full steps. Must be at least 2 and even.
+
+    .. note:: The ``StepperMotor`` class requires PWM frequencies > 1500. Specify
+      ``frequency=1500`` or higher when instantiating the above ``PWMOut`` objects.
     """
     def __init__(self, ain1, ain2, bin1, bin2, *, microsteps=16):
         self._coil = (ain2, bin1, ain1, bin2)

--- a/adafruit_motor/stepper.py
+++ b/adafruit_motor/stepper.py
@@ -73,10 +73,10 @@ class StepperMotor:
     def __init__(self, ain1, ain2, bin1, bin2, *, microsteps=16):
         self._coil = (ain2, bin1, ain1, bin2)
 
-	# set a safe pwm freq for each output
+        # reject unsafe (low) pwm freq
         for i in range(4):
             if self._coil[i].frequency < 1500:
-                self._coil[i].frequency = 2000
+                raise ValueError("PWMOut: 'frequency' must be at least 1500")
 
         self._current_microstep = 0
         if microsteps < 2:

--- a/examples/stepper_motor.py
+++ b/examples/stepper_motor.py
@@ -1,5 +1,5 @@
 # Run a Stepper Motor. Tested on ItsyBitsy M4 Express + DRV8833.
-#   https://www.adafruit.com/product/3800  
+#   https://www.adafruit.com/product/3800
 #   https://www.adafruit.com/product/3297
 
 import time

--- a/examples/stepper_motor.py
+++ b/examples/stepper_motor.py
@@ -1,39 +1,24 @@
-# This example uses an Adafruit Stepper and DC Motor FeatherWing to run a Stepper Motor.
-#   https://www.adafruit.com/product/2927
+# Run a Stepper Motor. Tested on ItsyBitsy M4 Express + DRV8833.
+#   https://www.adafruit.com/product/3800  
+#   https://www.adafruit.com/product/3297
 
 import time
 
-from board import SCL, SDA
-import busio
-
-# Import the PCA9685 module. Available in the bundle and here:
-#   https://github.com/adafruit/Adafruit_CircuitPython_PCA9685
-from adafruit_pca9685 import PCA9685
-
+import board
+import pulseio
 from adafruit_motor import stepper
 
-i2c = busio.I2C(SCL, SDA)
+AIn1 = pulseio.PWMOut(board.D9,  frequency=1600)
+AIn2 = pulseio.PWMOut(board.D10, frequency=1600)
+BIn1 = pulseio.PWMOut(board.D11, frequency=1600)
+BIn2 = pulseio.PWMOut(board.D12, frequency=1600)
 
-# Create a simple PCA9685 class instance for the Motor FeatherWing's default address.
-pca = PCA9685(i2c, address=0x60)
-pca.frequency = 1600
+stepper_motor = stepper.StepperMotor(AIn1, AIn2, BIn1, BIn2)
 
-# Motor 1 is channels 9 and 10 with 8 held high.
-# Motor 2 is channels 11 and 12 with 13 held high.
-# Motor 3 is channels 3 and 4 with 2 held high.
-# Motor 4 is channels 5 and 6 with 7 held high.
-
-pca.channels[7].duty_cycle = 0xffff
-pca.channels[2].duty_cycle = 0xffff
-stepper_motor = stepper.StepperMotor(pca.channels[4], pca.channels[3], # Motor 3
-                                     pca.channels[5], pca.channels[6]) # Motor 4
-
-for i in range(100):
+for i in range(1000):
     stepper_motor.onestep()
     time.sleep(0.01)
 
-for i in range(100):
+for i in range(1000):
     stepper_motor.onestep(direction=stepper.BACKWARD)
     time.sleep(0.01)
-
-pca.deinit()

--- a/examples/stepper_motor.py
+++ b/examples/stepper_motor.py
@@ -8,7 +8,7 @@ import board
 import pulseio
 from adafruit_motor import stepper
 
-AIn1 = pulseio.PWMOut(board.D9,  frequency=1600)
+AIn1 = pulseio.PWMOut(board.D9, frequency=1600)
 AIn2 = pulseio.PWMOut(board.D10, frequency=1600)
 BIn1 = pulseio.PWMOut(board.D11, frequency=1600)
 BIn2 = pulseio.PWMOut(board.D12, frequency=1600)

--- a/examples/stepper_motor_pca9685.py
+++ b/examples/stepper_motor_pca9685.py
@@ -1,0 +1,39 @@
+# This example uses an Adafruit Stepper and DC Motor FeatherWing to run a Stepper Motor.
+#   https://www.adafruit.com/product/2927
+
+import time
+
+from board import SCL, SDA
+import busio
+
+# Import the PCA9685 module. Available in the bundle and here:
+#   https://github.com/adafruit/Adafruit_CircuitPython_PCA9685
+from adafruit_pca9685 import PCA9685
+
+from adafruit_motor import stepper
+
+i2c = busio.I2C(SCL, SDA)
+
+# Create a simple PCA9685 class instance for the Motor FeatherWing's default address.
+pca = PCA9685(i2c, address=0x60)
+pca.frequency = 1600
+
+# Motor 1 is channels 9 and 10 with 8 held high.
+# Motor 2 is channels 11 and 12 with 13 held high.
+# Motor 3 is channels 3 and 4 with 2 held high.
+# Motor 4 is channels 5 and 6 with 7 held high.
+
+pca.channels[7].duty_cycle = 0xffff
+pca.channels[2].duty_cycle = 0xffff
+stepper_motor = stepper.StepperMotor(pca.channels[4], pca.channels[3], # Motor 3
+                                     pca.channels[5], pca.channels[6]) # Motor 4
+
+for i in range(100):
+    stepper_motor.onestep()
+    time.sleep(0.01)
+
+for i in range(100):
+    stepper_motor.onestep(direction=stepper.BACKWARD)
+    time.sleep(0.01)
+
+pca.deinit()


### PR DESCRIPTION
The ability to set the minimum frequency to 2000 requires `variable_frequency=True` for all four PWMOut objects. This consumes a counter for each object, and there aren't that many to go around.
If the minimum frequency is only checked, but not changed, then `variable_frequency` can be `False` and only one counter is used (assuming the frequency is the same for all the four PWMOut objects).
This way, external PWM drivers such as the [PCA9685](https://www.adafruit.com/product/815) are not strictly required.
Tested on [ItsyBitsy M4 Express](https://www.adafruit.com/product/3800) + [DRV8833](https://www.adafruit.com/product/3297).