### PR TITLE
Revert "Remove call to _update_coils in __init__"

### DIFF
--- a/adafruit_motor/stepper.py
+++ b/adafruit_motor/stepper.py
@@ -86,6 +86,7 @@ class StepperMotor:
         self._microsteps = microsteps
         self._curve = [int(round(0xffff * math.sin(math.pi / (2 * microsteps) * i)))
                        for i in range(microsteps + 1)]
+        self._update_coils()
 
     def _update_coils(self, *, microstepping=False):
         duty_cycles = [0, 0, 0, 0]

--- a/tests/test_stepper.py
+++ b/tests/test_stepper.py
@@ -33,7 +33,7 @@ def test_single_coil():
     motor = stepper.StepperMotor(coil[2], coil[0], coil[1], coil[3])
     # Always start with a single step.
     for j in range(4):
-        assert coil[j].duty_cycle == 0
+        assert coil[j].duty_cycle == (0xffff if j == 0 else 0)
     for i in range(1, 7): # Test 6 steps so we wrap around
         motor.onestep()
         for j in range(4):
@@ -45,7 +45,7 @@ def test_double_coil():
     motor = stepper.StepperMotor(coil[2], coil[0], coil[1], coil[3])
     # Despite double stepping we always start with a single step.
     for j in range(4):
-        assert coil[j].duty_cycle == 0
+        assert coil[j].duty_cycle == (0xffff if j == 0 else 0)
     for i in range(6): # Test 6 steps so we wrap around
         motor.onestep(style=stepper.DOUBLE)
         for j in range(4):
@@ -57,7 +57,7 @@ def test_interleave_steps():
     motor = stepper.StepperMotor(coil[2], coil[0], coil[1], coil[3])
     # We always start with a single step.
     for j in range(4):
-        assert coil[j].duty_cycle == 0
+        assert coil[j].duty_cycle == (0xffff if j == 0 else 0)
     for i in range(15): # Test 15 half steps so we wrap around
         motor.onestep(style=stepper.INTERLEAVE)
         for j in range(4):
@@ -83,7 +83,7 @@ def test_microstep_steps():
     motor = stepper.StepperMotor(coil[2], coil[0], coil[1], coil[3], microsteps=2)
     # We always start with a single step.
     for j in range(4):
-        assert coil[j].duty_cycle == 0
+        assert coil[j].duty_cycle == (0xffff if j == 0 else 0)
     motor.onestep(style=stepper.MICROSTEP)
     assert coil[0].duty_cycle == 0xb504
     assert coil[1].duty_cycle == 0xb504
@@ -114,7 +114,7 @@ def test_double_to_single():
     motor = stepper.StepperMotor(coil[2], coil[0], coil[1], coil[3])
     # We always start with a single step.
     for j in range(4):
-        assert coil[j].duty_cycle == 0
+        assert coil[j].duty_cycle == (0xffff if j == 0 else 0)
 
     motor.onestep(direction=stepper.BACKWARD, style=stepper.DOUBLE)
     assert coil[0].duty_cycle == 0xffff
@@ -146,7 +146,7 @@ def test_microstep_to_single():
     motor = stepper.StepperMotor(coil[2], coil[0], coil[1], coil[3])
     # We always start with a single step.
     for j in range(4):
-        assert coil[j].duty_cycle == 0
+        assert coil[j].duty_cycle == (0xffff if j == 0 else 0)
 
     motor.onestep(direction=stepper.BACKWARD, style=stepper.MICROSTEP)
     assert coil[0].duty_cycle == 0xfec3


### PR DESCRIPTION
Reverts adafruit/Adafruit_CircuitPython_Motor#29

This isn't appropriate because the library isn't designed for use when the pins are connected to something else. Starting with coils energized is a perfectly valid start state and changing it may break uses of the library. More details here: https://github.com/adafruit/Adafruit_CircuitPython_Crickit/issues/17#issuecomment-497815843