### PR TITLE
Add Recirculation Current Decay Mode Setter/Getter

### DIFF
--- a/adafruit_motor/motor.py
+++ b/adafruit_motor/motor.py
@@ -20,7 +20,7 @@ factors already.
 * Author(s): Scott Shawcroft
 """
 
-__version__ = "3.2.7"
+__version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_Motor.git"
 
 from micropython import const

--- a/adafruit_motor/motor.py
+++ b/adafruit_motor/motor.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2017 Scott Shawcroft  for Adafruit Industries
+# SPDX-FileCopyrightText: 2021 Scott Shawcroft for Adafruit Industries
 #
 # SPDX-License-Identifier: MIT
 
@@ -38,9 +38,9 @@ class DCMotor:
     threshold, speed-to-throttle linearity, and PWM frequency sensitivity.
 
     Decay mode settings only effect the operational performance of controller chips such
-    as the DRV8833, DRV8871, and TB6612. Although either decay mode setting is compatible
-    with discrete h-bridge controller circuitry such as the L9110H and L293D, operational
-    performance will not be altered.
+    as the DRV8833, DRV8871, and TB6612. Either decay mode setting is compatible
+    with discrete h-bridge controller circuitry such as the L9110H and L293D; operational
+    performance is not altered.
 
     :param ~pwmio.PWMOut positive_pwm: The motor input that causes the motor to spin forwards
       when high and the other is low.

--- a/adafruit_motor/motor.py
+++ b/adafruit_motor/motor.py
@@ -28,6 +28,7 @@ from micropython import const
 FAST_DECAY = const(0)  # Recirculation current fast decay mode (coasting)
 SLOW_DECAY = const(1)  # Recirculation current slow decay mode (braking)
 
+
 class DCMotor:
     """DC motor driver. ``positive_pwm`` and ``negative_pwm`` can be swapped if the motor runs in
     the opposite direction from what was expected for "forwards".
@@ -75,11 +76,11 @@ class DCMotor:
             duty_cycle = int(0xFFFF * abs(value))
             if self._decay_mode == SLOW_DECAY:  # Slow Decay (Braking) Mode
                 if value < 0:
-                    self._positive.duty_cycle = 0xffff - duty_cycle
-                    self._negative.duty_cycle = 0xffff
+                    self._positive.duty_cycle = 0xFFFF - duty_cycle
+                    self._negative.duty_cycle = 0xFFFF
                 else:
-                    self._positive.duty_cycle = 0xffff
-                    self._negative.duty_cycle = 0xffff - duty_cycle
+                    self._positive.duty_cycle = 0xFFFF
+                    self._negative.duty_cycle = 0xFFFF - duty_cycle
             else:  # Default Fast Decay (Coasting) Mode
                 if value < 0:
                     self._positive.duty_cycle = 0
@@ -100,7 +101,9 @@ class DCMotor:
         if mode in (FAST_DECAY, SLOW_DECAY):
             self._decay_mode = mode
         else:
-            raise ValueError("Decay mode value must be either motor.FAST_DECAY or motor.SLOW_DECAY")
+            raise ValueError(
+                "Decay mode value must be either motor.FAST_DECAY or motor.SLOW_DECAY"
+            )
 
     def __enter__(self):
         return self

--- a/adafruit_motor/motor.py
+++ b/adafruit_motor/motor.py
@@ -23,10 +23,11 @@ factors already.
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_Motor.git"
 
-from micropython import const
+FAST_DECAY = 0
+"""Recirculation current fast decay mode (coasting)"""
 
-FAST_DECAY = const(0)  # Recirculation current fast decay mode (coasting)
-SLOW_DECAY = const(1)  # Recirculation current slow decay mode (braking)
+SLOW_DECAY = 1
+"""Recirculation current slow decay mode (braking)"""
 
 
 class DCMotor:

--- a/examples/motor_pca9685_dc_motor.py
+++ b/examples/motor_pca9685_dc_motor.py
@@ -32,7 +32,9 @@ pca.frequency = 100
 # See here for more info: https://learn.adafruit.com/adafruit-motor-shield-v2-for-arduino/faq#faq-13
 pca.channels[7].duty_cycle = 0xFFFF
 motor4 = motor.DCMotor(pca.channels[5], pca.channels[6])
-motor4.decay_mode = motor.SLOW_DECAY  # Set motor to active braking mode to improve performance
+motor4.decay_mode = (
+    motor.SLOW_DECAY
+)  # Set motor to active braking mode to improve performance
 
 print("Forwards slow")
 motor4.throttle = 0.5

--- a/examples/motor_pca9685_dc_motor.py
+++ b/examples/motor_pca9685_dc_motor.py
@@ -32,6 +32,7 @@ pca.frequency = 100
 # See here for more info: https://learn.adafruit.com/adafruit-motor-shield-v2-for-arduino/faq#faq-13
 pca.channels[7].duty_cycle = 0xFFFF
 motor4 = motor.DCMotor(pca.channels[5], pca.channels[6])
+motor4.decay_mode = motor.SLOW_DECAY  # Set motor to active braking mode to improve performance
 
 print("Forwards slow")
 motor4.throttle = 0.5

--- a/tests/test_stepper.py
+++ b/tests/test_stepper.py
@@ -26,6 +26,7 @@ sys.modules["micropython"] = micropython
 
 from adafruit_motor import stepper  # pylint: disable-msg=wrong-import-position
 
+#pylint: disable=consider-using-in
 
 class Coil:
     """Class Coil"""

--- a/tests/test_stepper.py
+++ b/tests/test_stepper.py
@@ -35,10 +35,12 @@ class Coil:
 
     @property
     def frequency(self):
+        """Default frequency setting"""
         return 1500
 
     @property
     def duty_cycle(self):
+        """16-bit duty cycle value"""
         return self._duty_cycle
 
     @duty_cycle.setter
@@ -48,6 +50,7 @@ class Coil:
 
 
 def test_single_coil():
+    """Tests single coil"""
     coil = (Coil(), Coil(), Coil(), Coil())
     # We undo the coil order so our tests make more sense.
     motor = stepper.StepperMotor(coil[2], coil[0], coil[1], coil[3])
@@ -61,6 +64,7 @@ def test_single_coil():
 
 
 def test_double_coil():
+    """Tests double coil"""
     coil = (Coil(), Coil(), Coil(), Coil())
     # We undo the coil order so our tests make more sense.
     motor = stepper.StepperMotor(coil[2], coil[0], coil[1], coil[3])
@@ -76,6 +80,7 @@ def test_double_coil():
 
 
 def test_interleave_steps():
+    """Tests interleave steps"""
     coil = (Coil(), Coil(), Coil(), Coil())
     # We undo the coil order so our tests make more sense.
     motor = stepper.StepperMotor(coil[2], coil[0], coil[1], coil[3])
@@ -103,6 +108,7 @@ def test_interleave_steps():
 
 
 def test_microstep_steps():
+    """Tests microsteps"""
     coil = (Coil(), Coil(), Coil(), Coil())
     # We undo the coil order so our tests make more sense.
     motor = stepper.StepperMotor(coil[2], coil[0], coil[1], coil[3], microsteps=2)
@@ -135,6 +141,7 @@ def test_microstep_steps():
 
 
 def test_double_to_single():
+    """Tests double to single movement"""
     coil = (Coil(), Coil(), Coil(), Coil())
     # We undo the coil order so our tests make more sense.
     motor = stepper.StepperMotor(coil[2], coil[0], coil[1], coil[3])
@@ -168,6 +175,7 @@ def test_double_to_single():
 
 
 def test_microstep_to_single():
+    """Tests microsteps to single movement"""
     coil = (Coil(), Coil(), Coil(), Coil())
     # We undo the coil order so our tests make more sense.
     motor = stepper.StepperMotor(coil[2], coil[0], coil[1], coil[3])

--- a/tests/test_stepper.py
+++ b/tests/test_stepper.py
@@ -26,7 +26,8 @@ sys.modules["micropython"] = micropython
 
 from adafruit_motor import stepper  # pylint: disable-msg=wrong-import-position
 
-#pylint: disable=consider-using-in
+# pylint: disable=consider-using-in
+
 
 class Coil:
     """Class Coil"""

--- a/tests/test_stepper.py
+++ b/tests/test_stepper.py
@@ -2,6 +2,18 @@
 #
 # SPDX-License-Identifier: Unlicense
 
+"""
+`test_stepper`
+====================================================
+
+Tests stepper functionality.
+
+* Author(s): ladyada
+"""
+
+__version__ = "1.0.0"
+__repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_Motor.git"
+
 import os
 import sys
 from unittest.mock import MagicMock
@@ -16,6 +28,8 @@ from adafruit_motor import stepper  # pylint: disable-msg=wrong-import-position
 
 
 class Coil:
+    """Class Coil"""
+
     def __init__(self):
         self._duty_cycle = 0
 


### PR DESCRIPTION
Added the ability to selectively change DCMotor's default FAST_DECAY recirculation current decay mode (coasting mode) to SLOW_DECAY mode (braking mode) to significantly improve motor performance and throttle/speed linearity. For integrated motor controllers such as the TB6612 and DRV8833, switching to SLOW decay mode also reduces sensitivity to higher (>500Hz) PWM frequency. When coupled with a lower PWM frequency such as 25Hz, SLOW_DECAY mode increases torque at low motor speeds and contributes to a very low spin threshold speed.

FAST_DECAY will remain as the default decay mode for compatibility.

Usage example: 
```python
motor3.decay_mode = motor.FAST_DECAY  # set fast decay (coasting) mode
motor4.decay_mode = motor.SLOW_DECAY  # set slow decay (braking) mode
```

The braking mode change was successfully tested with TB6612 and DRV8833-based motor controllers (Crickit, MotorWing, MotorSheld, and various breakouts) as well as discrete h-bridge circuitry (such as L9110) using CircuitPython 6.1.0.

After this PR is finalized, I will completely rewrite the _Improve the Low Speed of Brushed DC Motors_ learning guide to elaborate on the new recirculation current decay mode improvements.

A big thank you goes to @ZodiusInfuser for the initial idea thread and subsequent discussions.

(reference: [https://github.com/adafruit/Adafruit_CircuitPython_Motor/issues/53](url)
