### PR TITLE
catch NotImplementedError

### DIFF
--- a/adafruit_motor/servo.py
+++ b/adafruit_motor/servo.py
@@ -16,7 +16,7 @@ try:
     from typing import Optional, Type
     from types import TracebackType
     from pwmio import PWMOut
-except ImportError:
+except (ImportError, NotImplementedError):
     pass
 
 


### PR DESCRIPTION
resolves #58 

allows to run in environments without `pwmio` implemented.