### PR TITLE
Import PWMOut protocols on applicable platforms

### DIFF
--- a/adafruit_motor/motor.py
+++ b/adafruit_motor/motor.py
@@ -23,7 +23,12 @@ factors already.
 try:
     from typing import Optional, Type
     from types import TracebackType
-    from pwmio import PWMOut
+
+    try:
+        from pwmio import PWMOut
+    except NotImplementedError:
+        from circuitpython_typing.pwmio import PWMOut
+
 except ImportError:
     pass
 

--- a/adafruit_motor/servo.py
+++ b/adafruit_motor/servo.py
@@ -17,7 +17,11 @@ try:
     from types import TracebackType
 
     # pylint: disable-msg=unused-import
-    from pwmio import PWMOut
+    try:
+        from pwmio import PWMOut
+    except NotImplementedError:
+        from circuitpython_typing.pwmio import PWMOut
+
 except (ImportError, NotImplementedError):
     pass
 

--- a/adafruit_motor/stepper.py
+++ b/adafruit_motor/stepper.py
@@ -20,8 +20,13 @@ from micropython import const
 
 try:
     from typing import Union, Optional
-    from pwmio import PWMOut
     from digitalio import DigitalInOut
+
+    try:
+        from pwmio import PWMOut
+    except NotImplementedError:
+        from circuitpython_typing.pwmio import PWMOut
+
 except ImportError:
     pass
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@
 #
 # SPDX-License-Identifier: Unlicense
 
-Adafruit-Blinka >= 7.0.0
+Adafruit-Blinka>=7.0.0
 adafruit-circuitpython-typing

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@
 # SPDX-License-Identifier: Unlicense
 
 Adafruit-Blinka>=7.0.0
-adafruit-circuitpython-typing
+adafruit-circuitpython-typing>=1.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@
 #
 # SPDX-License-Identifier: Unlicense
 
-Adafruit-Blinka
+Adafruit-Blinka >= 7.0.0
+adafruit-circuitpython-typing

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,10 @@ setup(
     # Author details
     author="Adafruit Industries",
     author_email="circuitpython@adafruit.com",
-    install_requires=["Adafruit-Blinka"],
+    install_requires=[
+        "Adafruit-Blinka>=7.0.0",
+        "adafruit-circuitpython-typing",
+    ],
     # Choose your license
     license="MIT",
     # See https://pypi.python.org/pypi?%3Aaction=list_classifiers

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     author_email="circuitpython@adafruit.com",
     install_requires=[
         "Adafruit-Blinka>=7.0.0",
-        "adafruit-circuitpython-typing",
+        "adafruit-circuitpython-typing>=1.5.0",
     ],
     # Choose your license
     license="MIT",


### PR DESCRIPTION
Resolves adafruit/Adafruit_CircuitPython_MotorKit/issues/45 by using new `circuitpython_typing.pwmio.PWMOut` `Protocol` for type annotations on platforms like the Jetson Nano which do not have `pwmio.PWMOut` implemented.