### PR TITLE
Fix Build CI issue for Sphinx 5.0.0

### DIFF
--- a/adafruit_motor/servo.py
+++ b/adafruit_motor/servo.py
@@ -113,7 +113,10 @@ class Servo(_BaseServo):
     ) -> None:
         super().__init__(pwm_out, min_pulse=min_pulse, max_pulse=max_pulse)
         self.actuation_range = actuation_range
-        """The physical range of motion of the servo in degrees."""
+        """The physical range of motion of the servo in degrees.
+        
+        :type: float
+        """
         self._pwm = pwm_out
 
     @property

--- a/adafruit_motor/servo.py
+++ b/adafruit_motor/servo.py
@@ -114,7 +114,7 @@ class Servo(_BaseServo):
         super().__init__(pwm_out, min_pulse=min_pulse, max_pulse=max_pulse)
         self.actuation_range = actuation_range
         """The physical range of motion of the servo in degrees.
-        
+
         :type: float
         """
         self._pwm = pwm_out

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -85,18 +85,6 @@ todo_include_todos = False
 # If this is True, todo emits a warning for each TODO entries. The default is False.
 todo_emit_warnings = True
 
-# Avoid an `= None` on instance attributes with their own doc strings.
-# Workaround from here: https://github.com/sphinx-doc/sphinx/issues/2044#issuecomment-285888160
-#
-from sphinx.ext.autodoc import ClassLevelDocumenter, InstanceAttributeDocumenter
-
-
-def iad_add_directive_header(self, sig):
-    ClassLevelDocumenter.add_directive_header(self, sig)
-
-
-InstanceAttributeDocumenter.add_directive_header = iad_add_directive_header
-
 # -- Options for HTML output ----------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for


### PR DESCRIPTION
Looks like `InstanceAttributeDocumenter` was removed in Sphinx 5.0.0.  Doesn't look like it's needed for it's original purpose (documenting `Servo.actuation_range`) since its documenting just fine with the code removed.

I've also added the type to the docstring so it shows up in the documentation.