### PR TITLE
Fix error caused by non-existent variable_frequency property

### DIFF
--- a/adafruit_motor/stepper.py
+++ b/adafruit_motor/stepper.py
@@ -116,11 +116,11 @@ class StepperMotor:
                 if self._coil[i].frequency < 1500:
                     try:
                         self._coil[i].frequency = 2000
-                    except AttributeError:
+                    except AttributeError as err:
                         raise ValueError(
                             "PWMOut outputs must either be set to at least "
                             "1500 Hz or allow variable frequency."
-                        )
+                        ) from err
             if microsteps < 2:
                 raise ValueError("Microsteps must be at least 2")
             if microsteps % 2 == 1:

--- a/adafruit_motor/stepper.py
+++ b/adafruit_motor/stepper.py
@@ -114,7 +114,10 @@ class StepperMotor:
             self._coil = (ain2, bin1, ain1, bin2)
             for i in range(4):
                 if self._coil[i].frequency < 1500:
-                    if hasattr(self._coil[i], "variable_frequency") and not self._coil[i].variable_frequency:
+                    if (
+                        hasattr(self._coil[i], "variable_frequency")
+                        and not self._coil[i].variable_frequency
+                    ):
                         raise ValueError(
                             "PWMOut outputs must either be set to at least "
                             "1500 Hz or allow variable frequency."

--- a/adafruit_motor/stepper.py
+++ b/adafruit_motor/stepper.py
@@ -114,15 +114,13 @@ class StepperMotor:
             self._coil = (ain2, bin1, ain1, bin2)
             for i in range(4):
                 if self._coil[i].frequency < 1500:
-                    if (
-                        hasattr(self._coil[i], "variable_frequency")
-                        and not self._coil[i].variable_frequency
-                    ):
+                    try:
+                        self._coil[i].frequency = 2000
+                    except AttributeError:
                         raise ValueError(
                             "PWMOut outputs must either be set to at least "
                             "1500 Hz or allow variable frequency."
                         )
-                    self._coil[i].frequency = 2000
             if microsteps < 2:
                 raise ValueError("Microsteps must be at least 2")
             if microsteps % 2 == 1:

--- a/adafruit_motor/stepper.py
+++ b/adafruit_motor/stepper.py
@@ -114,7 +114,7 @@ class StepperMotor:
             self._coil = (ain2, bin1, ain1, bin2)
             for i in range(4):
                 if self._coil[i].frequency < 1500:
-                    if not self._coil[i].variable_frequency:
+                    if hasattr(self._coil[i], "variable_frequency") and not self._coil[i].variable_frequency:
                         raise ValueError(
                             "PWMOut outputs must either be set to at least "
                             "1500 Hz or allow variable frequency."


### PR DESCRIPTION
This is in regards to https://forums.adafruit.com/viewtopic.php?p=958532.

This fixes an issue introduced by #67 because the `variable_frequency` is not a property of PWMOut according to https://docs.circuitpython.org/en/latest/shared-bindings/pwmio/index.html nor is it a property of the [Seesaw PWMOut](https://github.com/adafruit/Adafruit_CircuitPython_seesaw/blob/main/adafruit_seesaw/pwmout.py) which is used on the Raspberry Pi. I'm not sure if it exists in certain instances, so I just added a check if it has the attribute before trying to use it.